### PR TITLE
Revert "Add CPU usage monitoring, just for the mixer loop..." for now

### DIFF
--- a/it2play/src/it2play.c
+++ b/it2play/src/it2play.c
@@ -36,20 +36,6 @@ static void handleArguments(int argc, char *argv[]);
 static void readKeyboard(void);
 static int32_t renderToWav(void);
 
-double timingFunction()
-{
-#ifdef _WIN32
-	LARGE_INTEGER performanceFrequency, performanceCounter;
-	QueryPerformanceFrequency(&performanceFrequency);
-	QueryPerformanceCounter(&performanceCounter);
-	return ((double)performanceCounter.QuadPart) / ((double)performanceFrequency.QuadPart);
-#else
-	struct timespec t;
-	clock_gettime(CLOCK_MONOTONIC, &t);
-	return t.tv_sec + ((double)t.tv_nsec) / 1000000000.0;
-#endif
-}
-
 // yuck!
 #ifdef _WIN32
 void wavRecordingThread(void *arg)
@@ -153,10 +139,6 @@ int main(int argc, char *argv[])
 	modifyTerminal();
 #endif
 
-	Music_RegisterTimingFunction(timingFunction);
-
-	double cpuMax = 0.0;
-
 	programRunning = true;
 	while (programRunning)
 	{
@@ -171,18 +153,11 @@ int main(int argc, char *argv[])
 		if (order < 0) // this can happen for a split second when you decrease the position :)
 			order = 0;
 
-		double timeSpent, timeIdle;
-		Music_GetTiming(&timeSpent, &timeIdle);
-
-		double cpuUsage = ((timeSpent + timeIdle) > 0) ? timeSpent * 100.0 / (timeSpent + timeIdle) : 0.0;
-		if (cpuUsage > cpuMax) cpuMax = cpuUsage;
-
-		printf("Row: %03d/%03d - Pos: %03d - BPM: %3d - Speed: %3d - Channels: %3d (%d) - CPU: %.2f%% (%.2f%%)      \r",
+		printf("Row: %03d/%03d - Pos: %03d - BPM: %3d - Speed: %3d - Channels: %3d (%d)      \r",
 			Song.CurrentRow, Song.NumberOfRows,
 			order,
 			Song.Tempo, Song.CurrentSpeed,
-			activeVoices, highestVoiceCount,
-			cpuUsage, cpuMax);
+			activeVoices, highestVoiceCount);
 		fflush(stdout);
 
 		Sleep(50);

--- a/it2play/src/posix.h
+++ b/it2play/src/posix.h
@@ -27,7 +27,6 @@ bool createSingleThread(void *(*threadFunc)(void *arg));
 #include <string.h>
 #include <unistd.h>
 #include <pthread.h>
-#include <time.h>
 
 void Sleep(uint32_t ms);
 void modifyTerminal(void);

--- a/it_music.c
+++ b/it_music.c
@@ -42,13 +42,6 @@ static double *dLinearSlideUpTable, *dLinearSlideDownTable;
 #endif
 static char MIDIDataArea[(9+16+128)*32];
 
-static Music_TimingFunction TimingFunction = NULL;
-static double TimingStart = -1.0;
-static double TimingEnd = -1.0;
-static double TimingLastEnd = -1.0;
-static double TimeSpent = 0.0;
-static double TimeIdle = 0.0;
-
 /* 8bb: These have been changed to be easier to understand,
 ** and to be 32-bit/64-bit pointer compliant.
 */
@@ -1900,33 +1893,8 @@ void Music_FillAudioBuffer(int16_t *buffer, int32_t numSamples)
 		return;
 	}
 
-	if (TimingFunction)
-	{
-		TimingLastEnd = TimingEnd;
-		TimingStart = TimingFunction();
-	}
-
 	if (DriverMix != NULL)
 		DriverMix(numSamples, buffer);
-
-	if (TimingFunction)
-	{
-		TimingEnd = TimingFunction();
-		TimeSpent += TimingEnd - TimingStart;
-		if (TimingLastEnd >= 0)
-			TimeIdle += TimingStart - TimingLastEnd;
-	}
-}
-
-void Music_GetTiming(double * _TimeSpent, double * _TimeIdle)
-{
-	if (_TimeSpent) *_TimeSpent = TimeSpent, TimeSpent = 0;
-	if (_TimeIdle) *_TimeIdle = TimeIdle, TimeIdle = 0;
-}
-
-void Music_RegisterTimingFunction(Music_TimingFunction func)
-{
-	TimingFunction = func;
 }
 
 bool Music_Init(int32_t mixingFrequency, int32_t mixingBufferSize, int32_t DriverType)

--- a/it_music.h
+++ b/it_music.h
@@ -81,8 +81,4 @@ void Music_ReleaseAllPatterns(void);
 int32_t Music_GetActiveVoices(void); // 8bb: added this
 bool Music_RenderToWAV(const char *filenameOut); // 8bb: added this
 
-typedef double (*Music_TimingFunction)(void);
-void Music_RegisterTimingFunction(Music_TimingFunction func);
-void Music_GetTiming(double * TimeSpent, double * TimeIdle);
-
 extern bool WAVRender_Flag; // 8bb: added this


### PR DESCRIPTION
I don't think this shows correct information. Around 2.5-3% CPU usage to mix 11 voices with integer mixing on an i9-9900K? Reverting it for now.