### PR TITLE
Reimplement thread time usage monitoring...

### DIFF
--- a/it2play/src/posix.h
+++ b/it2play/src/posix.h
@@ -27,6 +27,7 @@ bool createSingleThread(void *(*threadFunc)(void *arg));
 #include <string.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <time.h>
 
 void Sleep(uint32_t ms);
 void modifyTerminal(void);

--- a/it_music.c
+++ b/it_music.c
@@ -42,6 +42,14 @@ static double *dLinearSlideUpTable, *dLinearSlideDownTable;
 #endif
 static char MIDIDataArea[(9+16+128)*32];
 
+static Music_TimingFunction TimingFunction = NULL;
+static double TimingStart = -1.0;
+static double TimingEnd = -1.0;
+static double TimingLastMonotonic = -1.0;
+static double TimingMonotonic = -1.0;
+static double TimeSpent = 0.0;
+static double TimeIdle = 0.0;
+
 /* 8bb: These have been changed to be easier to understand,
 ** and to be 32-bit/64-bit pointer compliant.
 */
@@ -1893,8 +1901,34 @@ void Music_FillAudioBuffer(int16_t *buffer, int32_t numSamples)
 		return;
 	}
 
+	if (TimingFunction)
+	{
+		TimingLastMonotonic = TimingMonotonic;
+		TimingStart = TimingFunction(0);
+		TimingMonotonic = TimingFunction(1);
+	}
+
 	if (DriverMix != NULL)
 		DriverMix(numSamples, buffer);
+
+	if (TimingFunction)
+	{
+		TimingEnd = TimingFunction(0);
+		TimeSpent += TimingEnd - TimingStart;
+		if (TimingLastMonotonic >= 0)
+			TimeIdle += TimingMonotonic - TimingLastMonotonic;
+	}
+}
+
+void Music_GetTiming(double * _TimeSpent, double * _TimeIdle)
+{
+	if (_TimeSpent) *_TimeSpent = TimeSpent, TimeSpent = 0;
+	if (_TimeIdle) *_TimeIdle = TimeIdle, TimeIdle = 0;
+}
+
+void Music_RegisterTimingFunction(Music_TimingFunction func)
+{
+	TimingFunction = func;
 }
 
 bool Music_Init(int32_t mixingFrequency, int32_t mixingBufferSize, int32_t DriverType)

--- a/it_music.h
+++ b/it_music.h
@@ -81,4 +81,8 @@ void Music_ReleaseAllPatterns(void);
 int32_t Music_GetActiveVoices(void); // 8bb: added this
 bool Music_RenderToWAV(const char *filenameOut); // 8bb: added this
 
+typedef double (*Music_TimingFunction)(int isRealTime);
+void Music_RegisterTimingFunction(Music_TimingFunction func);
+void Music_GetTiming(double * TimeSpent, double * TimeIdle);
+
 extern bool WAVRender_Flag; // 8bb: added this


### PR DESCRIPTION
...with more appropriate usage label

Yes, this is approximate thread time usage, so 100% is a single core, not the entire CPU. CPU usage by whole CPU is a fickle thing anyway, considering that some systems, especially Apple Silicon Macs, and Alder Lake Intel CPUs, have unbalanced CPU power per core, so the total figure depends on which core the app is running the mixer on. The only appropriate way to do that is to measure CPU time of the current thread instead of real time of the system clock or performance counters. I don't know the appropriate way to do this, so it's best to try this approximation as-is for now.

Do you know both Posix and Windows ways to retrieve the current thread's CPU time figure? That is what the timer function should be returning, in as much precision as it can, and then the total figure should be calculated from real time spent running.