### PR TITLE
Fix build on linux (missing header)

### DIFF
--- a/it2drivers/hq_fixsample.c
+++ b/it2drivers/hq_fixsample.c
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "../it_structs.h"
 
 /* TODO:


### PR DESCRIPTION
stddef.h provides `NULL`.